### PR TITLE
Refactor to composite action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
         uses: ./
         id: releases
         with:
-          releases: '7.3, 5.6'
+          releases: '7.4, 7.3'
 
   current_php_releases:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,22 +2,27 @@ on: [push]
 
 jobs:
   output_releases:
+    name: Generate PHP Releases Array
     runs-on: ubuntu-latest
     outputs:
       range: ${{ steps.releases.outputs.range }}
     steps:
+      # we won't need this first 'uses' step when the action is published, just for local use
       - name: Checkout
         uses: actions/checkout@v2
 
       - name: Fetch Current Releases
         uses: ./
         id: releases
+        with:
+          releases: '7.3, 5.6'
 
   current_php_releases:
     runs-on: ubuntu-latest
     needs: output_releases
     strategy:
-      matrix: ${{ fromJSON(needs.output_releases.outputs.range) }}
+      matrix:
+        php: ${{ fromJSON(needs.output_releases.outputs.range) }}
     name: PHP ${{ matrix.php }}
     steps:
       - name: Echo PHP

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,15 +4,9 @@ jobs:
   output_releases:
     name: Generate PHP Releases Array
     runs-on: ubuntu-latest
-    outputs:
-      range: ${{ steps.releases.outputs.range }}
     steps:
-      # we won't need this first 'uses' step when the action is published, just for local use
-      - name: Checkout
-        uses: actions/checkout@v2
-
       - name: Fetch Current Releases
-        uses: ./
+        uses: tighten/phpreleases-action@v1
         id: releases
         with:
           releases: '7.4, 7.3'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,0 @@
-# Container image that runs your code
-FROM dwdraju/alpine-curl-jq
-
-# Copies your code file from your action repository to the filesystem path `/` of the container
-COPY entrypoint.sh /entrypoint.sh
-
-# Code file to execute when the docker container starts up (`entrypoint.sh`)
-ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -1,9 +1,45 @@
 # PHP Releases Action
-Docker container action to consume the PHP Releases API for use within GitHub Actions.
+Generates an array of supported PHP releases for use within a GitHub Actions matrix.
 
-## Requirements
+## Usage
+Within your workflow `jobs` block, add the following job _before_ your matrix job:
+```yaml
+  output_releases:
+    name: Generate PHP Releases Array
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Current Releases
+        uses: tighten/phpreleases-action@v1
+        id: releases
+```
+If you need to add specific versions to the matrix statically (to ensure they're included regardless of current support), add them as a comma separated list with the `releases` key:
+```yaml
+  output_releases:
+    name: Generate PHP Releases Array
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Current Releases
+        uses: tighten/phpreleases-action@v1
+        id: releases
+        with:
+          releases: '7.4, 7.3'
+```
 
-## Installation
+A full sample is available in this repo's [.github/workflows directory](https://github.com/tighten/phpreleases-action/blob/main/.github/workflows/main.yml).
+
+Then, refer to the `output_releases` job's output in the `php` line of your matrix strategy, like below:
+```yaml
+  strategy:
+    matrix:
+      php: ${{ fromJSON(needs.output_releases.outputs.range) }}
+```
+
+You can implement additional matrix values (os or laravel versions, for example), as well as include/exclude combinations [as you normally would with a matrix](https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs).
+
+## Issues
+If you encounter any issues in the implementation of this workflow, or have feature ideas, feel free to [open a github issue](https://github.com/tighten/phpreleases-action/issues/new).
+
+Thanks for using the PHP releases github action!
 
 ## Contributing
 Please see [CONTRIBUTING](CONTRIBUTING.md) for details.

--- a/README.md
+++ b/README.md
@@ -8,14 +8,13 @@ By default, this action uses the [PHP Releases API](https://phpreleases.com/) to
   # This job will need to run before the job that defines the matrix.
   output_releases:
     name: Generate PHP Releases Array
-	  # Requires a machine that can execute bash and make http requests.
+    # Requires a machine that can execute bash and make http requests.
     runs-on: ubuntu-latest
     steps:
       - name: Fetch Current Releases
         uses: tighten/phpreleases-action@v1
         id: releases
- ### Create a matrix from the return value
-```yaml
+ # Create a matrix from the return value
   current_php_releases:
     runs-on: ubuntu-latest
     # The matrix cannot be built before the job has finished.
@@ -25,6 +24,7 @@ By default, this action uses the [PHP Releases API](https://phpreleases.com/) to
         # GitHub Actions expression to get the return value.
         php: ${{ fromJSON(needs.output_releases.outputs.range) }}
     name: PHP ${{ matrix.php }}
+```
 
 A full sample is available in this repo's [.github/workflows directory](https://github.com/tighten/phpreleases-action/blob/main/.github/workflows/main.yml).
 
@@ -84,6 +84,8 @@ jobs:
       with:
           php-version: ${{ matrix.php }}
           extensions: posix, dom, curl, libxml, mbstring, zip, pcntl, bcmath, soap, intl, gd, exif, iconv, imagick
+```
+
 ## Issues
 If you need to report an issue or a feature idea, let us know by [opening a GitHub Issue](https://github.com/tighten/phpreleases-action/issues/new).
 

--- a/action.yml
+++ b/action.yml
@@ -54,23 +54,18 @@ runs:
         latest="${{ steps.parse-latest.outputs.latest-release }}"
         minAct="${{ steps.parse-min.outputs.min-active-release }}"
         minSec="${{ steps.parse-min.outputs.min-security-release }}"
-
-#        No user input
+        
         if [ -z ${{ steps.store-user-input.outputs.user-input }} ]; then
           echo "::set-output name=releases-array::$(echo [${latest}, ${minAct}, ${minSec}])"
-#        User input
         else
-#          Read user input into array
           userInput="${{ steps.store-user-input.outputs.user-input }}"
           IFS=', ' read -r -a array <<< "$userInput"
-#          Add generated versions to the array
           array+=(${latest} ${minAct} ${minSec})
-#          Remove duplicates
           deduped=($(echo "${array[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' '))
 
-#          Format array to a string
           printf -v formatted ',%s' "${deduped[@]}"
           formatted=${formatted:1}
+          echo "${formatted}"
 
           echo "::set-output name=releases-array::$(echo [${formatted}])"
         fi

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
-name: 'Test Releases'
-description: 'Should output the latest release'
+name: 'PHP Releases'
+description: 'Generates an array of the latest, minimum security, and minimum active PHP releases, along with user defined versions'
 inputs:
   releases:
     required: false

--- a/action.yml
+++ b/action.yml
@@ -65,7 +65,6 @@ runs:
 
           printf -v formatted ',%s' "${deduped[@]}"
           formatted=${formatted:1}
-          echo "${formatted}"
 
           echo "::set-output name=releases-array::$(echo [${formatted}])"
         fi

--- a/action.yml
+++ b/action.yml
@@ -1,9 +1,59 @@
-# action.yml
-name: 'Current PHP Releases'
-description: 'Get data from PHPReleases.com'
+name: 'Test Releases'
+description: 'Should output the latest release'
+inputs:
+  releases:
+    required: false
+    description: 'Add specific versions to the matrix array'
 outputs:
   range:
-    description: 'Should be a range'
+    description: "Releases Array"
+    value: ${{ steps.return-response.outputs.releases-array }}
 runs:
-  using: 'docker'
-  image: 'Dockerfile'
+  using: "composite"
+  steps:
+    - name: Store user input
+      id: store-user-input
+      shell: bash
+      run: |
+        echo "::set-output name=user-input::$(echo ${{ inputs.releases }})"
+    - name: Make Latest Request
+      id: make-latest-request
+      uses: fjogeleit/http-request-action@v1
+      with:
+        url: 'https://phpreleases.com/api/releases/latest'
+        method: 'GET'
+    - name: Make Security Request
+      id: make-security-request
+      uses: fjogeleit/http-request-action@v1
+      with:
+        url: 'https://phpreleases.com/api/releases/minimum-supported/security'
+        method: 'GET'
+    - name: Make Active Request
+      id: make-active-request
+      uses: fjogeleit/http-request-action@v1
+      with:
+        url: 'https://phpreleases.com/api/releases/minimum-supported/active'
+        method: 'GET'
+    - name: Parse Latest
+      id: parse-latest
+      shell: bash
+      run: |
+        latest=${{ steps.make-latest-request.outputs.response }}
+        IFS='.'
+        read -ra arr <<< "$latest"
+        echo "::set-output name=latest-release::$(echo ${arr[0]}.${arr[1]})"
+    - name: Parse Minimum Supported
+      id: parse-min
+      shell: bash
+      run: |
+        echo "::set-output name=min-active-release::$(echo ${{ fromJSON(steps.make-active-request.outputs.response).provided.major }}.${{ fromJSON(steps.make-active-request.outputs.response).provided.minor }})"
+        echo "::set-output name=min-security-release::$(echo ${{ fromJSON(steps.make-security-request.outputs.response).provided.major }}.${{ fromJSON(steps.make-security-request.outputs.response).provided.minor }})"
+    - name: Return Response
+      id: return-response
+      run: |
+        if [ -z ${{ steps.store-user-input.outputs.user-input }} ]; then
+        echo "::set-output name=releases-array::$(echo ['${{ steps.parse-latest.outputs.latest-release }}', '${{ steps.parse-min.outputs.min-active-release }}', '${{ steps.parse-min.outputs.min-security-release }}'])"
+        else
+        echo "::set-output name=releases-array::$(echo ['${{ steps.parse-latest.outputs.latest-release }}', '${{ steps.parse-min.outputs.min-active-release }}', '${{ steps.parse-min.outputs.min-security-release }}', '${{ steps.store-user-input.outputs.user-input }}'])"
+        fi
+      shell: bash

--- a/action.yml
+++ b/action.yml
@@ -51,9 +51,27 @@ runs:
     - name: Return Response
       id: return-response
       run: |
+        latest="${{ steps.parse-latest.outputs.latest-release }}"
+        minAct="${{ steps.parse-min.outputs.min-active-release }}"
+        minSec="${{ steps.parse-min.outputs.min-security-release }}"
+
+#        No user input
         if [ -z ${{ steps.store-user-input.outputs.user-input }} ]; then
-        echo "::set-output name=releases-array::$(echo ['${{ steps.parse-latest.outputs.latest-release }}', '${{ steps.parse-min.outputs.min-active-release }}', '${{ steps.parse-min.outputs.min-security-release }}'])"
+          echo "::set-output name=releases-array::$(echo [${latest}, ${minAct}, ${minSec}])"
+#        User input
         else
-        echo "::set-output name=releases-array::$(echo ['${{ steps.parse-latest.outputs.latest-release }}', '${{ steps.parse-min.outputs.min-active-release }}', '${{ steps.parse-min.outputs.min-security-release }}', '${{ steps.store-user-input.outputs.user-input }}'])"
+#          Read user input into array
+          userInput="${{ steps.store-user-input.outputs.user-input }}"
+          IFS=', ' read -r -a array <<< "$userInput"
+#          Add generated versions to the array
+          array+=(${latest} ${minAct} ${minSec})
+#          Remove duplicates
+          deduped=($(echo "${array[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' '))
+
+#          Format array to a string
+          printf -v formatted ',%s' "${deduped[@]}"
+          formatted=${formatted:1}
+
+          echo "::set-output name=releases-array::$(echo [${formatted}])"
         fi
       shell: bash

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,0 @@
-#!/bin/sh -l
-
-Minimum=$(curl -k --url 'https://phpreleases.com/api/releases/minimum-supported/active' | jq -r '(.major|tostring) + "." + (.minor|tostring)')
-Latest=$(curl -k --url 'https://phpreleases.com/api/releases/latest' | jq -r 'split(".") | .[0] + "." + .[1]')
-
-echo "::set-output name=range::{\"include\":[{\"php\":\"${Minimum}\"},{\"php\":\"${Latest}\"}]}"


### PR DESCRIPTION
This refactor moves from a docker container action to a [composite action](https://docs.github.com/en/actions/creating-actions/creating-a-composite-action).

In different steps, we're building up an array to include [`latest release`, `minimum active support`, `minimum security support`, `user input releases (optional)`]. This array can then be passed into a matrix's `php` block to generate combinations. 

I added a dedupe so we won't risk duplicating matrix runs for the same php release (say, a user specifies `8.0`, but it's also in the returned array).

Unfortunately, for implementing this, we'll still have to generate and output the data in a job prior to the matrix job, then pass the output into the `php` matrix line. 

Example:

```
  output_releases:
    name: Generate PHP Releases Array
    runs-on: ubuntu-latest
    outputs:
      range: ${{ steps.releases.outputs.range }}
    steps:
      - name: Fetch Current Releases
        uses: ./
        id: releases
        with:
          releases: '7.3, 5.6'
```